### PR TITLE
Remove margin on dropdown content

### DIFF
--- a/LCCA-stylesheet.css
+++ b/LCCA-stylesheet.css
@@ -257,6 +257,7 @@ div {
 	padding: .25em;
 	border: 2px groove darkgray;
 	border-radius: 1em;
+	margin: 0;
 }
 .dropdown:hover .dropdown-content {
 	display:block;


### PR DESCRIPTION
Remove margin on dropdown content. This fixes display error in Chrome, where default margin meant that content was displayed too far below corresponding menu item.