### PR TITLE
Rearrange top menu, alter CSS

### DIFF
--- a/2018-minutes.html
+++ b/2018-minutes.html
@@ -7,7 +7,7 @@
 	<meta name="description" content="Homepage for the Louisa County Commission on Aging.">
 	<meta name="author" content="Brendan Ferreri-Hanberry" />
 	<link rel="schema.dcterms" href="http://purl.org/dc/terms/">
-	<meta name="dcterms.modified" content="2020-3-9" />
+	<meta name="dcterms.modified" content="2020-3-19" />
 	<meta name="viewport" content="width=device-width initial-scale=1" >
 	<meta charset="UTF-8">
 	<link rel="stylesheet" type="text/css" href="LCCA-stylesheet.css" />
@@ -66,21 +66,6 @@ $(document).ready(function(){
 	</div>
 </div>
 <menu class="top-menu">
-		<li class="dropdown">
-	    <button>ABOUT</button>
-		<ul class="dropdown-content">
-			<li><a href="LCCA-bylaws.pdf" download>BYLAWS</a></li>
-			<li><a href="index.html#mission">MISSION</a></li>
-			<li class="dropdown-submenu">
-			<a href="#" id="minutes-button">MINUTES</a>
-			<ul class="dropdown-content" id="minutes-list">
-			    <li><a href="2018-minutes.html">2018</a></li>
-				<li><a href="2019-minutes.html">2019</a></li>
-				<li><a href="2020-minutes.html">2020</a></li>
-			</ul>
-			</li>
-		</ul>
-	</li>
 	<li class="dropdown">
 		<button>GET INVOLVED</button>
 		<ul class="dropdown-content">
@@ -89,21 +74,12 @@ $(document).ready(function(){
 		</ul>
 	</li>
 	<li class="dropdown">
-		<button>CONTACT US</button>
-		<ul class="dropdown-content">
-			<li><a href="mailto:LCCOAinfo@gmail.com">EMAIL</a></li>
-			<li><a href="contact-list.html">MEMBER LIST</a></li>
-		</ul>
-	</li>
-	<li class="dropdown">
-	<li class="dropdown">
 		<button>VOLUNTEERING</button>
 		<ul class="dropdown-content">
 			<li><a href="https://www.jabacares.org/volunteer-services-landing" target="_blank">VOLUNTEERING AT JABA</a></li>
 			<li><a href="https://www.jabacares.org/become-a-volunteer" target="_blank">POSITIONS AVAILABLE AT JABA</a></li>
 			<li><a href="https://www.louisacounty.com/903/Board-and-Committee-Vacancies" target="_blank">BOARD AND COMMITTEE VACANCIES</a></li>
 		</ul>
-	</li>
 	</li>
 	<li class="dropdown">
 		<button>RESOURCES</button>
@@ -113,6 +89,23 @@ $(document).ready(function(){
 			<li><a href="https://www.aarp.org" target="_blank"><abbr title="American Association of Retired Persons">AARP</abbr></a></li>
 			<li><a href="https://www.ncoa.org" target="_blank"><abbr title="National Council on Aging">NCOA</abbr></a></li>
 			<li><a href="https://acl.gov/programs" target="_blank"><abbr title="Administration for Community Living">ACL</abbr></a></li>
+		</ul>
+	</li>
+		<li class="dropdown">
+	    <button>ABOUT</button>
+		<ul class="dropdown-content">
+			<li><a href="LCCA-bylaws.pdf" download>BYLAWS</a></li>
+			<li><a href="mailto:LCCOAinfo@gmail.com">EMAIL</a></li>
+			<li><a href="contact-list.html">MEMBER LIST</a></li>
+			<li><a href="#mission">MISSION</a></li>
+			<li class="dropdown-submenu">
+			<a href="#" id="minutes-button">MINUTES</a>
+			<ul class="dropdown-content" id="minutes-list">
+			    <li><a href="2018-minutes.html">2018</a></li>
+				<li><a href="2019-minutes.html">2019</a></li>
+				<li><a href="2020-minutes.html">2020</a></li>
+			</ul>
+			</li>
 		</ul>
 	</li>
 </menu>

--- a/2019-minutes.html
+++ b/2019-minutes.html
@@ -7,7 +7,7 @@
 	<meta name="description" content="Homepage for the Louisa County Commission on Aging.">
 	<meta name="author" content="Brendan Ferreri-Hanberry" />
 	<link rel="schema.dcterms" href="http://purl.org/dc/terms/">
-	<meta name="dcterms.modified" content="2020-3-9" />
+	<meta name="dcterms.modified" content="2020-3-19" />
 	<meta name="viewport" content="width=device-width initial-scale=1" >
 	<meta charset="UTF-8">
 	<link rel="stylesheet" type="text/css" href="LCCA-stylesheet.css" />
@@ -66,33 +66,11 @@ $(document).ready(function(){
 	</div>
 </div>
 <menu class="top-menu">
-		<li class="dropdown">
-	    <button>ABOUT</button>
-		<ul class="dropdown-content">
-			<li><a href="LCCA-bylaws.pdf" download>BYLAWS</a></li>
-			<li><a href="index.html#mission">MISSION</a></li>
-			<li class="dropdown-submenu">
-			<a href="#" id="minutes-button">MINUTES</a>
-			<ul class="dropdown-content" id="minutes-list">
-			    <li><a href="2018-minutes.html">2018</a></li>
-				<li><a href="2019-minutes.html">2019</a></li>
-				<li><a href="2020-minutes.html">2020</a></li>
-			</ul>
-			</li>
-		</ul>
-	</li>
 	<li class="dropdown">
 		<button>GET INVOLVED</button>
 		<ul class="dropdown-content">
 			<li><a href="mailto:LCCOAinfo@gmail.com?subject=joining a committee">JOIN A COMMITTEE</a></li>
 			<li><a href="mailto:LCCOAinfo@gmail.com?subject=becoming a member">BECOME A MEMBER</a></li>
-		</ul>
-	</li>
-	<li class="dropdown">
-		<button>CONTACT US</button>
-		<ul class="dropdown-content">
-			<li><a href="mailto:LCCOAinfo@gmail.com">EMAIL</a></li>
-			<li><a href="contact-list.html">MEMBER LIST</a></li>
 		</ul>
 	</li>
 	<li class="dropdown">
@@ -111,6 +89,23 @@ $(document).ready(function(){
 			<li><a href="https://www.aarp.org" target="_blank"><abbr title="American Association of Retired Persons">AARP</abbr></a></li>
 			<li><a href="https://www.ncoa.org" target="_blank"><abbr title="National Council on Aging">NCOA</abbr></a></li>
 			<li><a href="https://acl.gov/programs" target="_blank"><abbr title="Administration for Community Living">ACL</abbr></a></li>
+		</ul>
+	</li>
+		<li class="dropdown">
+	    <button>ABOUT</button>
+		<ul class="dropdown-content">
+			<li><a href="LCCA-bylaws.pdf" download>BYLAWS</a></li>
+			<li><a href="mailto:LCCOAinfo@gmail.com">EMAIL</a></li>
+			<li><a href="contact-list.html">MEMBER LIST</a></li>
+			<li><a href="#mission">MISSION</a></li>
+			<li class="dropdown-submenu">
+			<a href="#" id="minutes-button">MINUTES</a>
+			<ul class="dropdown-content" id="minutes-list">
+			    <li><a href="2018-minutes.html">2018</a></li>
+				<li><a href="2019-minutes.html">2019</a></li>
+				<li><a href="2020-minutes.html">2020</a></li>
+			</ul>
+			</li>
 		</ul>
 	</li>
 </menu>

--- a/2020-minutes.html
+++ b/2020-minutes.html
@@ -7,7 +7,7 @@
 	<meta name="description" content="Homepage for the Louisa County Commission on Aging.">
 	<meta name="author" content="Brendan Ferreri-Hanberry" />
 	<link rel="schema.dcterms" href="http://purl.org/dc/terms/">
-	<meta name="dcterms.modified" content="2020-3-9" />
+	<meta name="dcterms.modified" content="2020-3-19" />
 	<meta name="viewport" content="width=device-width initial-scale=1" >
 	<meta charset="UTF-8">
 	<link rel="stylesheet" type="text/css" href="LCCA-stylesheet.css" />
@@ -66,33 +66,11 @@ $(document).ready(function(){
 	</div>
 </div>
 <menu class="top-menu">
-		<li class="dropdown">
-	    <button>ABOUT</button>
-		<ul class="dropdown-content">
-			<li><a href="LCCA-bylaws.pdf" download>BYLAWS</a></li>
-			<li><a href="index.html#mission">MISSION</a></li>
-			<li class="dropdown-submenu">
-			<a href="#" id="minutes-button">MINUTES</a>
-			<ul class="dropdown-content" id="minutes-list">
-			    <li><a href="2018-minutes.html">2018</a></li>
-				<li><a href="2019-minutes.html">2019</a></li>
-				<li><a href="2020-minutes.html">2020</a></li>
-			</ul>
-			</li>
-		</ul>
-	</li>
 	<li class="dropdown">
 		<button>GET INVOLVED</button>
 		<ul class="dropdown-content">
 			<li><a href="mailto:LCCOAinfo@gmail.com?subject=joining a committee">JOIN A COMMITTEE</a></li>
 			<li><a href="mailto:LCCOAinfo@gmail.com?subject=becoming a member">BECOME A MEMBER</a></li>
-		</ul>
-	</li>
-	<li class="dropdown">
-		<button>CONTACT US</button>
-		<ul class="dropdown-content">
-			<li><a href="mailto:LCCOAinfo@gmail.com">EMAIL</a></li>
-			<li><a href="contact-list.html">MEMBER LIST</a></li>
 		</ul>
 	</li>
 	<li class="dropdown">
@@ -111,6 +89,23 @@ $(document).ready(function(){
 			<li><a href="https://www.aarp.org" target="_blank"><abbr title="American Association of Retired Persons">AARP</abbr></a></li>
 			<li><a href="https://www.ncoa.org" target="_blank"><abbr title="National Council on Aging">NCOA</abbr></a></li>
 			<li><a href="https://acl.gov/programs" target="_blank"><abbr title="Administration for Community Living">ACL</abbr></a></li>
+		</ul>
+	</li>
+		<li class="dropdown">
+	    <button>ABOUT</button>
+		<ul class="dropdown-content">
+			<li><a href="LCCA-bylaws.pdf" download>BYLAWS</a></li>
+			<li><a href="mailto:LCCOAinfo@gmail.com">EMAIL</a></li>
+			<li><a href="contact-list.html">MEMBER LIST</a></li>
+			<li><a href="#mission">MISSION</a></li>
+			<li class="dropdown-submenu">
+			<a href="#" id="minutes-button">MINUTES</a>
+			<ul class="dropdown-content" id="minutes-list">
+			    <li><a href="2018-minutes.html">2018</a></li>
+				<li><a href="2019-minutes.html">2019</a></li>
+				<li><a href="2020-minutes.html">2020</a></li>
+			</ul>
+			</li>
 		</ul>
 	</li>
 </menu>

--- a/LCCA-stylesheet.css
+++ b/LCCA-stylesheet.css
@@ -1,4 +1,4 @@
-/*Last updated 3-9-2020*/
+/*Last updated 3-19-2020*/
 
 /*Begin media queries based on screen width*/
 
@@ -101,7 +101,7 @@ span {
 }
 }
 
-@media (min-width: 30em) and (max-width: 55em)
+@media (min-width: 30em) and (max-width: 53em)
 {
 h1 {
 	font-size: 32px;
@@ -139,7 +139,7 @@ menu {
 }
 }
 
-@media (min-width: 55em)
+@media (min-width: 53em)
 {
 body {
     width: 70%;		
@@ -176,9 +176,9 @@ menu {
 	max-width: 100%;
 }
 .top-menu {
-	max-width: 80%;
+	max-width: 85%;
 	margin: 10px auto 0 auto;
-	padding: 0 auto !important;
+	padding: 0 5px !important;
 }
 
 .size {
@@ -189,14 +189,25 @@ menu {
 }
 }
 
+@media (min-width: 75em) and (max-width: 90em)
+{
+	.top-menu {
+		max-width: 67%;
+	}
+}
+
+@media (min-width: 90em)
+{
+	.top-menu {
+		max-width: 55%;	
+	}
+}
+
 @media (min-width: 95em)
 {
-.top-menu {
-	max-width: 60%;	
-}
-.bottom-menu{
-    max-width: 80%;		
-}
+	.bottom-menu{
+		max-width: 85%;		
+	}
 }
 
 /*End media queries based on screen width*/

--- a/contact-list.html
+++ b/contact-list.html
@@ -7,7 +7,7 @@
 	<meta name="description" content="Homepage for the Louisa County Commission on Aging.">
 	<meta name="author" content="Brendan Ferreri-Hanberry" />
 	<link rel="schema.dcterms" href="http://purl.org/dc/terms/">
-	<meta name="dcterms.modified" content="2020-3-9" />
+	<meta name="dcterms.modified" content="2020-3-19" />
 	<meta name="viewport" content="width=device-width initial-scale=1" >
 	<meta charset="UTF-8">
 	<link rel="stylesheet" type="text/css" href="LCCA-stylesheet.css" />
@@ -34,33 +34,11 @@
 	</div>
 </div>
 <menu class="top-menu">
-		<li class="dropdown">
-	    <button>ABOUT</button>
-		<ul class="dropdown-content">
-			<li><a href="LCCA-bylaws.pdf" download>BYLAWS</a></li>
-			<li><a href="index.html#mission">MISSION</a></li>
-			<li class="dropdown-submenu">
-			<a href="#" id="minutes-button">MINUTES</a>
-			<ul class="dropdown-content" id="minutes-list">
-			    <li><a href="2018-minutes.html">2018</a></li>
-				<li><a href="2019-minutes.html">2019</a></li>
-				<li><a href="2020-minutes.html">2020</a></li>
-			</ul>
-			</li>
-		</ul>
-	</li>
 	<li class="dropdown">
 		<button>GET INVOLVED</button>
 		<ul class="dropdown-content">
 			<li><a href="mailto:LCCOAinfo@gmail.com?subject=joining a committee">JOIN A COMMITTEE</a></li>
 			<li><a href="mailto:LCCOAinfo@gmail.com?subject=becoming a member">BECOME A MEMBER</a></li>
-		</ul>
-	</li>
-	<li class="dropdown">
-		<button>CONTACT US</button>
-		<ul class="dropdown-content">
-			<li><a href="mailto:LCCOAinfo@gmail.com">EMAIL</a></li>
-			<li><a href="contact-list.html">MEMBER LIST</a></li>
 		</ul>
 	</li>
 	<li class="dropdown">
@@ -79,6 +57,23 @@
 			<li><a href="https://www.aarp.org" target="_blank"><abbr title="American Association of Retired Persons">AARP</abbr></a></li>
 			<li><a href="https://www.ncoa.org" target="_blank"><abbr title="National Council on Aging">NCOA</abbr></a></li>
 			<li><a href="https://acl.gov/programs" target="_blank"><abbr title="Administration for Community Living">ACL</abbr></a></li>
+		</ul>
+	</li>
+		<li class="dropdown">
+	    <button>ABOUT</button>
+		<ul class="dropdown-content">
+			<li><a href="LCCA-bylaws.pdf" download>BYLAWS</a></li>
+			<li><a href="mailto:LCCOAinfo@gmail.com">EMAIL</a></li>
+			<li><a href="contact-list.html">MEMBER LIST</a></li>
+			<li><a href="#mission">MISSION</a></li>
+			<li class="dropdown-submenu">
+			<a href="#" id="minutes-button">MINUTES</a>
+			<ul class="dropdown-content" id="minutes-list">
+			    <li><a href="2018-minutes.html">2018</a></li>
+				<li><a href="2019-minutes.html">2019</a></li>
+				<li><a href="2020-minutes.html">2020</a></li>
+			</ul>
+			</li>
 		</ul>
 	</li>
 </menu>

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
 	<meta name="description" content="Homepage for the Louisa County Commission on Aging.">
 	<meta name="author" content="Brendan Ferreri-Hanberry" />
 	<link rel="schema.dcterms" href="http://purl.org/dc/terms/">
-	<meta name="dcterms.modified" content="2020-3-9" />
+	<meta name="dcterms.modified" content="2020-3-19" />
 	<meta name="viewport" content="width=device-width initial-scale=1" >
 	<meta charset="UTF-8">
 	<link rel="stylesheet" type="text/css" href="LCCA-stylesheet.css" />
@@ -38,32 +38,10 @@
 </div>
 <menu class="top-menu">
 	<li class="dropdown">
-	    <button>ABOUT</button>
-		<ul class="dropdown-content">
-			<li><a href="LCCA-bylaws.pdf" download>BYLAWS</a></li>
-			<li><a href="#mission">MISSION</a></li>
-			<li class="dropdown-submenu">
-			<a href="#" id="minutes-button">MINUTES</a>
-			<ul class="dropdown-content" id="minutes-list">
-			    <li><a href="2018-minutes.html">2018</a></li>
-				<li><a href="2019-minutes.html">2019</a></li>
-				<li><a href="2020-minutes.html">2020</a></li>
-			</ul>
-			</li>
-		</ul>
-	</li>
-	<li class="dropdown">
 		<button>GET INVOLVED</button>
 		<ul class="dropdown-content">
 			<li><a href="mailto:LCCOAinfo@gmail.com?subject=joining a committee">JOIN A COMMITTEE</a></li>
 			<li><a href="mailto:LCCOAinfo@gmail.com?subject=becoming a member">BECOME A MEMBER</a></li>
-		</ul>
-	</li>
-	<li class="dropdown">
-		<button>CONTACT US</button>
-		<ul class="dropdown-content">
-			<li><a href="mailto:LCCOAinfo@gmail.com">EMAIL</a></li>
-			<li><a href="contact-list.html">MEMBER LIST</a></li>
 		</ul>
 	</li>
 	<li class="dropdown">
@@ -82,6 +60,23 @@
 			<li><a href="https://www.aarp.org" target="_blank"><abbr title="American Association of Retired Persons">AARP</abbr></a></li>
 			<li><a href="https://www.ncoa.org" target="_blank"><abbr title="National Council on Aging">NCOA</abbr></a></li>
 			<li><a href="https://acl.gov/programs" target="_blank"><abbr title="Administration for Community Living">ACL</abbr></a></li>
+		</ul>
+	</li>
+		<li class="dropdown">
+	    <button>ABOUT</button>
+		<ul class="dropdown-content">
+			<li><a href="LCCA-bylaws.pdf" download>BYLAWS</a></li>
+			<li><a href="mailto:LCCOAinfo@gmail.com">EMAIL</a></li>
+			<li><a href="contact-list.html">MEMBER LIST</a></li>
+			<li><a href="#mission">MISSION</a></li>
+			<li class="dropdown-submenu">
+			<a href="#" id="minutes-button">MINUTES</a>
+			<ul class="dropdown-content" id="minutes-list">
+			    <li><a href="2018-minutes.html">2018</a></li>
+				<li><a href="2019-minutes.html">2019</a></li>
+				<li><a href="2020-minutes.html">2020</a></li>
+			</ul>
+			</li>
 		</ul>
 	</li>
 </menu>


### PR DESCRIPTION
Rearrange top menu to include contact info under About rather than its own dropdown. Adjust CSS to compensate for smaller menu width.