### PR TITLE
alter media queries re: header

### DIFF
--- a/LCCA-stylesheet.css
+++ b/LCCA-stylesheet.css
@@ -1,4 +1,4 @@
-/*Last updated 3-19-2020*/
+/*Last updated 3-27-2020*/
 
 /*Begin media queries based on screen width*/
 
@@ -59,9 +59,7 @@ menu {
 	max-width: 100%;
 	padding: 0 5px !important;
 }
-.small {
-	display:none;
-}
+
 span {
 	margin: 0;
 }
@@ -88,12 +86,6 @@ input {
 	border: 2px outset darkgray;
 	padding: .35em;
 	width: 180px;
-}
-
-.small {
-	max-height:2em;
-	max-width:2em;
-	margin: -0.3em 0.5em 0 -0.5em;
 }
 
 span {
@@ -137,6 +129,29 @@ menu {
 	padding: 0 5px !important;
 	max-width: 100%;
 }
+}
+@media (max-width: 37em)
+{
+	.small {
+		display:none;
+	}
+}
+
+@media (min-width: 37em)
+{
+	.small {
+	max-height:2em !important;
+	max-width:2em !important;
+	margin: -0.3em 0.5em 0 -0.5em !important;
+}
+
+}
+
+@media (min-width: 51em)
+{
+	* {
+		box-sizing: border-box;
+	}
 }
 
 @media (min-width: 53em)
@@ -183,9 +198,6 @@ menu {
 
 .size {
     margin: -4em 0 0 0;	
-}
-* {
-    box-sizing: border-box;
 }
 }
 
@@ -399,6 +411,32 @@ li {
 .news {
 	text-align: center;
 }
+
+
+.right {
+	float:right;
+}
+
+.search {
+	height: 28px;
+	width: 36px; 
+}
+section {
+	display:block;
+	clear: both;
+	background-color: transparent;
+	border: 5px groove gray;
+	padding: 0.625em 1em;
+	color: white;
+}
+
+/* Carousel */
+.carousel {
+  max-width: 800px;
+  position: relative;
+  margin: auto;
+}
+
 /* Next & previous buttons */
 .next {
   right: 0;
@@ -427,33 +465,11 @@ li {
   font-size: 18px;
   transition: 0.6s ease;
 }
+
 /* On hover, add a black background color with a little bit see-through */
 .prev:hover, .next:hover {
   background-color: rgba(0,0,0,0.8);
   text-decoration: none;
-}
-.right {
-	float:right;
-}
-
-.search {
-	height: 28px;
-	width: 36px; 
-}
-section {
-	display:block;
-	clear: both;
-	background-color: transparent;
-	border: 5px groove gray;
-	padding: 0.625em 1em;
-	color: white;
-}
-
-/* Carousel */
-.carousel {
-  max-width: 800px;
-  position: relative;
-  margin: auto;
 }
 
 .submit {


### PR DESCRIPTION
Make minor changes to the media queries which define how the header is displayed at different widths. This is to avoid awkward positioning of elements in the header near breakpoints.