### PR TITLE
improve wording

### DIFF
--- a/Little-Yellow-Book-construction.html
+++ b/Little-Yellow-Book-construction.html
@@ -8,7 +8,7 @@
 	from the Louisa County Commission on Aging.">
 	<meta name="author" content="Brendan Ferreri-Hanberry" />
 	<link rel="schema.dcterms" href="http://purl.org/dc/terms/">
-	<meta name="dcterms.modified" content="2020-3-31" />
+	<meta name="dcterms.modified" content="2020-4-29" />
 	<meta name="viewport" content="width=device-width initial-scale=1" >
 	<meta charset="UTF-8">
 	<link rel="stylesheet" type="text/css" href="LYB-stylesheet.css" />
@@ -67,7 +67,7 @@
 		which are open to the public. 
 		<br />
 		<br />
-		For more information, please click the email link in the footer.
+		For more information, please click the email link below.
 	</section>
 </div>
 <hr />


### PR DESCRIPTION
Change the wording from "email link in the footer" to "email link below."